### PR TITLE
Prototype CloudFormation template

### DIFF
--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -1,0 +1,263 @@
+Description: A CloudFormation template for deploying Raster Vision Batch jobs to AWS.
+
+Parameters:
+  Project:
+    Type: String
+    Default: Raster Vision
+    Description: Name of the project associated with the Batch job
+
+  Environment:
+    Type: String
+    Default: Staging
+    Description: Environment of the project being deployed (e.g. Staging, Development, Production)
+
+  Region:
+    Type: String
+    Default: 'us-east-1'
+    Description: AWS Region in which to deploy the Batch job
+
+  AMI:
+    Type: 'AWS::EC2::Image::Id'
+    Default: ami-06681f03ed7f21643
+    Description: Amazon Machine Image to use for the compute environment
+
+  KeyName:
+    Type: 'AWS::EC2::KeyPair::KeyName'
+    Description: An Amazon EC2 key pair name to use for SSH access to the cluster
+
+  SpotFleetBidPercentage:
+    Type: Number
+    Default: 100
+    Description: >
+      Minimum percentage that a Spot Instance price must be when compared with
+      the On-Demand price for that instance type before instances are launched
+
+  MinimumVCPUs:
+    Type: Number
+    Default: 0
+    Description: The minimum number of EC2 vCPUs that an environment should maintain
+
+  DesiredVCPUs:
+    Type: Number
+    Default: 0
+    Description: The desired number of EC2 vCPUS in the compute environment
+
+  MaxVCPUs:
+    Type: Number
+    Default: 80
+    Description: The maximum number of EC2 vCPUs that an environment can reach
+
+  InstanceTypes:
+    Type: List<String>
+    Default: p2.xlarge
+    Description: A list of instance types that may be launched
+
+  JobDefinitionName:
+    Type: String
+    Default: 'raster-vision-gpu'
+    Description: Specifies the name of the Batch job definition
+
+  InstanceVCPUs:
+    Type: Number
+    Default: 8
+    Description: Number of VCPUs reserved for the container by the task definition
+
+  InstanceMemory:
+    Type: Number
+    Default: 55000
+    Description: The hard limit (in MB) of memory to present to the container
+
+  BatchServiceRolePolicyARN:
+    Type: String
+    Default: 'arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole'
+    Description: The ARN of the IAM role to assign to running Batch instances
+
+  SpotFleetServiceRolePolicyARN:
+    Type: String
+    Default: 'arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole'
+    Description: The ARN of the IAM role to assign to running spot fleet instances
+
+  RepositoryName:
+    Type: String
+    Default: rastervision
+    Description: Specifies the name of the ECR repository to retrieve images from
+
+  ImageName:
+    Type: String
+    Default: 'raster-vision-gpu'
+    Description: Specifies the name of the container image to pull for Batch jobs
+
+  ImageTag:
+    Type: String
+    Default: latest
+    Description: Tag of the image to retrieve from ECR
+
+  VPC:
+    Type: 'AWS::EC2::VPC::Id'
+    Description: Virtual Private Cloud in which to launch Batch instances
+
+  SubnetIds:
+    Type: 'List<AWS:EC2::Subnet::Id>'
+    Description: >
+      A list of IDs of subnets in which to launch Batch instances (all subnets
+      must exist in the VPC you selected)
+
+Resources:
+  BatchServiceIAMRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          -
+            Effect: Allow
+            Action:
+              - 'sts:AssumeRole'
+            Principal:
+              Service:
+                - batch.amazonaws.com
+      ManagedPolicyArns:
+        - !Ref BatchServiceRolePolicyARN
+
+  SpotFleetIAMRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          -
+            Effect: Allow
+            Action:
+              - 'sts:AssumeRole'
+            Principal:
+              Service:
+                - spotfleet.amazonaws.com
+      ManagedPolicyArns:
+        - !Ref SpotFleetServiceRolePolicyARN
+
+  BatchInstanceIAMRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          -
+            Effect: Allow
+            Action:
+              - 'sts:AssumeRole'
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role'
+        - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
+
+  BatchInstanceProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Path: /
+      Roles:
+        - !Ref BatchInstanceIAMRole
+      InstanceProfileName: !Join ['', ['BatchIAM', !Ref Environment]]
+
+  ContainerInstanceSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        -
+          FromPort: 22
+          ToPort: 22
+          IpProtocol: tcp
+          CidrIp: 0.0.0.0/0
+        -
+          FromPort: 6006
+          ToPort: 6006
+          IpProtocol: tcp
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        -
+          FromPort: 0
+          ToPort: 0
+          IpProtocol: tcp
+          CidrIp: 0.0.0.0/0
+      Tags:
+        -
+          Key: Name
+          Value: !Join ['', ['sgRasterVisionContainerInstance' !Ref Environment]]
+        -
+          Key: Project
+          Value: !Ref Project
+        -
+          Key: Environment
+          Value: !Ref Environment
+
+  Repository:
+    Type: 'AWS::ECR::Repository',
+    RepositoryName: !Ref RepositoryName
+
+  BatchComputeEnvironment:
+    Type: 'AWS::Batch::ComputeEnvironment'
+    Properties:
+      ComputeEnvironmentName: !Join ['', ['rasterVisionBatch', !Ref Environment, 'ComputeEnvironment']]
+      Type: Managed
+      State: ENABLED
+      ServiceRole: !Ref BatchServiceIAMRole
+      ComputeResources:
+        Type: SPOT
+        BidPercentage: !Ref SpotFleetBidPercentage
+        Ec2KeyPair: !Ref KeyName
+        ImageId: !Ref AMI
+        MinvCpus: !Ref MinimumVCPUS
+        DesiredvCpus: !Ref DesiredVCPUs
+        MaxvCpus: !Ref MaximumVCPUs
+        SpotIamFleetRole: !Ref SpotFleetIAMRole
+        InstanceRole: !Ref BatchInstanceProfile
+        Instancetypes: !Ref InstanceTypes
+        SecurityGroupIds:
+          - !Ref ContainerInstanceSecurityGroup
+        Subnets: !Split [',', !Ref SubnetIds]
+        Tags:
+          -
+            Key: Name
+            Value: Raster Vision BatchWorker
+          -
+            Key: ComputeEnvironment
+            Value: Raster Vision
+          -
+            Key: Project
+            Value: !Ref Project
+          -
+            Key: Environment
+            Value: !Ref Environment
+
+  BatchJobQueue:
+    Type: 'AWS::Batch::JobQueue'
+    Properties:
+      JobQueueName: !Join ['' , ['rasterVisionQueue', !Ref Environment]]
+      Priority: 1
+      State: ENABLED
+      ComputeEnvironmentOrder:
+        -
+          ComputeEnvironment: !Ref BatchComputeEnvironment
+          Order: 1
+
+  JobDefinition:
+    JobDefinitionName: !Ref JobDefinitionName
+    Type: Container
+    ContainerProperties:
+      Image: !Join ['', [!GetAtt Repository.Arn, '/', !Ref ImageName, ':', !Ref ImageTag]]
+      Vcpus: !Ref InstanceVCPUs
+      Memory: !Ref InstanceMemory
+      Volumes:
+        -
+          Host:
+            SourcePath: /home/ec2-user
+          Name: home
+      MountPoints:
+        -
+          ContainerPath: /opt/data
+          ReadOnly: false
+          SourceVolume: home
+      ReadOnlyRootFilesystem: false
+      Privileged: true

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -1,7 +1,7 @@
 Description: A CloudFormation template for deploying Raster Vision Batch jobs to AWS.
 
 Metadata:
-  'AWS::CloudFormation::Interface':
+  AWS::CloudFormation::Interface:
     ParameterGroups:
       -
         Label:
@@ -124,7 +124,7 @@ Parameters:
 
   JobDefinitionName:
     Type: String
-    Default: 'raster-vision-gpu-testing'
+    Default: raster-vision-gpu-testing
     Description: Specifies the name of the Batch Job Definition to create
 
   InstanceVCPUs:
@@ -139,12 +139,12 @@ Parameters:
 
   RepositoryName:
     Type: String
-    Default: 'raster-vision-testing'
+    Default: raster-vision-testing
     Description: Specifies the name of the ECR repository to create and retrieve images from
 
   ImageName:
     Type: String
-    Default: 'raster-vision-gpu'
+    Default: raster-vision-gpu
     Description: Specifies the name of the container image to pull for Batch jobs
 
   ImageTag:
@@ -153,67 +153,67 @@ Parameters:
     Description: Tag of the container image to retrieve from ECR
 
   VPC:
-    Type: 'AWS::EC2::VPC::Id'
+    Type: AWS::EC2::VPC::Id
     Description: Virtual Private Cloud in which to launch Batch instances
 
   SubnetIds:
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Type: List<AWS::EC2::Subnet::Id>
     Description: >
       A list of IDs of subnets in which to launch Batch instances (all subnets
       must exist in the VPC you selected)
 
 Resources:
   BatchServiceIAMRole:
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: 2012-10-17
         Statement:
           -
             Effect: Allow
             Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
             Principal:
               Service:
                 - batch.amazonaws.com
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole'
+        - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
 
   SpotFleetIAMRole:
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: 2012-10-17
         Statement:
           -
             Effect: Allow
             Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
             Principal:
               Service:
                 - spotfleet.amazonaws.com
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole'
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
 
   BatchInstanceIAMRole:
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: 2012-10-17
         Statement:
           -
             Effect: Allow
             Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
             Principal:
               Service:
                 - ec2.amazonaws.com
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role'
-        - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
 
   BatchInstanceProfile:
-    Type: 'AWS::IAM::InstanceProfile'
+    Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
       Roles:
@@ -221,7 +221,7 @@ Resources:
       InstanceProfileName: !Join ['', ['BatchIAM', !Ref Environment]]
 
   ContainerInstanceSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
+    Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref VPC
       GroupDescription: !Join ['', ['Security group for ', !Ref Project, ' (', !Ref Environment, ')']]
@@ -245,7 +245,7 @@ Resources:
       Tags:
         -
           Key: Name
-          Value: 'sgRasterVisionContainerInstance'
+          Value: sgRasterVisionContainerInstance
         -
           Key: Project
           Value: !Ref Project
@@ -254,12 +254,12 @@ Resources:
           Value: !Ref Environment
 
   Repository:
-    Type: 'AWS::ECR::Repository'
+    Type: AWS::ECR::Repository
     Properties:
       RepositoryName: !Ref RepositoryName
 
   BatchComputeEnvironment:
-    Type: 'AWS::Batch::ComputeEnvironment'
+    Type: AWS::Batch::ComputeEnvironment
     Properties:
       ComputeEnvironmentName: !Join ['', ['rasterVisionBatch', !Ref Environment, 'ComputeEnvironment']]
       Type: Managed
@@ -286,7 +286,7 @@ Resources:
           Environment: !Ref Environment
 
   BatchJobQueue:
-    Type: 'AWS::Batch::JobQueue'
+    Type: AWS::Batch::JobQueue
     Properties:
       JobQueueName: !Join ['' , ['rasterVisionQueue', !Ref Environment]]
       Priority: 1
@@ -297,7 +297,7 @@ Resources:
           Order: 1
 
   JobDefinition:
-    Type: 'AWS::Batch::JobDefinition'
+    Type: AWS::Batch::JobDefinition
     Properties:
       Type: Container
       JobDefinitionName: !Ref JobDefinitionName

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -116,10 +116,6 @@ Parameters:
   InstanceTypes:
     Type: List<String>
     Default: p2.xlarge
-    AllowedValues:
-      - p2.xlarge
-      - p2.8xlarge
-      - p2.16xlarge
     Description: A comma-separated list of instance types that may be launched
 
   JobDefinitionName:

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -9,7 +9,6 @@ Metadata:
         Parameters:
           - Project
           - Environment
-          - Region
       -
         Label:
           default: EC2 Instance Configuration
@@ -36,15 +35,11 @@ Metadata:
           default: Batch Configuration
         Parameters:
           - JobDefinitionName
-          - BatchServiceRolePolicyARN
-          - SpotFleetServiceRolePolicyARN
     ParameterLabels:
       Project:
         default: Name
       Environment:
         default: Environment
-      Region:
-        default: AWS Region
       AMI:
         default: AMI
       KeyName:
@@ -65,10 +60,6 @@ Metadata:
         default: vCPU Limit
       InstanceMemory:
         default: Memory Limit
-      BatchServiceRolePolicyARN:
-        default: Batch Service Role
-      SpotFleetServiceRolePolicyARN:
-        default: Spot Fleet Service Role
       RepositoryName:
         default: Repository Name
       ImageName:
@@ -88,26 +79,21 @@ Parameters:
 
   Environment:
     Type: String
-    Default: Testing
+    Default: Unknown
     Description: Environment of the project being deployed (e.g. Staging, Development, Production)
 
-  Region:
-    Type: String
-    Default: 'us-east-1'
-    Description: AWS Region in which to deploy the Batch job
-
   AMI:
-    Type: String
-    Default: 'ami-06681f03ed7f21643'
+    Type: AWS::EC2::Image::Id
+    Default: ami-06681f03ed7f21643
     Description: Amazon Machine Image to use for the compute environment
 
   KeyName:
-    Type: 'AWS::EC2::KeyPair::KeyName'
+    Type: AWS::EC2::KeyPair::KeyName
     Description: An Amazon EC2 key pair name to use for SSH access to the cluster
 
   SpotFleetBidPercentage:
     Type: Number
-    Default: 100
+    Default: 40
     Description: >
       Minimum percentage that a Spot Instance price must be when compared with
       the On-Demand price for that instance type before instances are launched
@@ -130,6 +116,10 @@ Parameters:
   InstanceTypes:
     Type: List<String>
     Default: p2.xlarge
+    AllowedValues:
+      - p2.xlarge
+      - p2.8xlarge
+      - p2.16xlarge
     Description: A comma-separated list of instance types that may be launched
 
   JobDefinitionName:
@@ -146,16 +136,6 @@ Parameters:
     Type: Number
     Default: 55000
     Description: The hard limit (in MB) of memory to present to the container
-
-  BatchServiceRolePolicyARN:
-    Type: String
-    Default: 'arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole'
-    Description: The ARN of the IAM role to assign to running Batch instances
-
-  SpotFleetServiceRolePolicyARN:
-    Type: String
-    Default: 'arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole'
-    Description: The ARN of the IAM role to assign to running spot fleet instances
 
   RepositoryName:
     Type: String
@@ -197,7 +177,7 @@ Resources:
               Service:
                 - batch.amazonaws.com
       ManagedPolicyArns:
-        - !Ref BatchServiceRolePolicyARN
+        - 'arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole'
 
   SpotFleetIAMRole:
     Type: 'AWS::IAM::Role'
@@ -213,7 +193,7 @@ Resources:
               Service:
                 - spotfleet.amazonaws.com
       ManagedPolicyArns:
-        - !Ref SpotFleetServiceRolePolicyARN
+        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole'
 
   BatchInstanceIAMRole:
     Type: 'AWS::IAM::Role'
@@ -265,7 +245,7 @@ Resources:
       Tags:
         -
           Key: Name
-          Value: !Join ['', ['sgRasterVisionContainerInstance', !Ref Environment]]
+          Value: 'sgRasterVisionContainerInstance'
         -
           Key: Project
           Value: !Ref Project

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -1,14 +1,94 @@
 Description: A CloudFormation template for deploying Raster Vision Batch jobs to AWS.
 
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+      -
+        Label:
+          default: Project Configuration
+        Parameters:
+          - Project
+          - Environment
+          - Region
+      -
+        Label:
+          default: EC2 Instance Configuration
+        Parameters:
+          - VPC
+          - SubnetIds
+          - KeyName
+          - AMI
+          - InstanceTypes
+          - MinimumVCPUs
+          - DesiredVCPUs
+          - MaximumVCPUs
+      -
+        Label:
+          default: Docker Container Configuration
+        Parameters:
+          - RepositoryName
+          - ImageName
+          - ImageTag
+          - InstanceVCPUs
+          - InstanceMemory
+      -
+        Label:
+          default: Batch Configuration
+        Parameters:
+          - JobDefinitionName
+          - BatchServiceRolePolicyARN
+          - SpotFleetServiceRolePolicyARN
+    ParameterLabels:
+      Project:
+        default: Name
+      Environment:
+        default: Environment
+      Region:
+        default: AWS Region
+      AMI:
+        default: AMI
+      KeyName:
+        default: SSH Key Name
+      SpotFleetBidPercentage:
+        default: Spot Fleet Bid Percentage
+      MinimumVCPUs:
+        default: Minimum vCPU Count
+      DesiredVCPUs:
+        default: Desired vCPU Count
+      MaximumVCPUs:
+        default: Maximum vCPU Count
+      InstanceTypes:
+        default: Instance Types
+      JobDefinitionName:
+        default: Job Definition Name
+      InstanceVCPUs:
+        default: vCPU Limit
+      InstanceMemory:
+        default: Memory Limit
+      BatchServiceRolePolicyARN:
+        default: Batch Service Role
+      SpotFleetServiceRolePolicyARN:
+        default: Spot Fleet Service Role
+      RepositoryName:
+        default: Repository Name
+      ImageName:
+        default: Image Name
+      ImageTag:
+        default: Image Tag
+      VPC:
+        default: VPC
+      SubnetIds:
+        default: Subnets
+
 Parameters:
   Project:
     Type: String
-    Default: Raster Vision
+    Default: Raster Vision CloudFormation
     Description: Name of the project associated with the Batch job
 
   Environment:
     Type: String
-    Default: Staging
+    Default: Testing
     Description: Environment of the project being deployed (e.g. Staging, Development, Production)
 
   Region:
@@ -17,8 +97,8 @@ Parameters:
     Description: AWS Region in which to deploy the Batch job
 
   AMI:
-    Type: 'AWS::EC2::Image::Id'
-    Default: ami-06681f03ed7f21643
+    Type: String
+    Default: 'ami-06681f03ed7f21643'
     Description: Amazon Machine Image to use for the compute environment
 
   KeyName:
@@ -42,7 +122,7 @@ Parameters:
     Default: 0
     Description: The desired number of EC2 vCPUS in the compute environment
 
-  MaxVCPUs:
+  MaximumVCPUs:
     Type: Number
     Default: 80
     Description: The maximum number of EC2 vCPUs that an environment can reach
@@ -50,17 +130,17 @@ Parameters:
   InstanceTypes:
     Type: List<String>
     Default: p2.xlarge
-    Description: A list of instance types that may be launched
+    Description: A comma-separated list of instance types that may be launched
 
   JobDefinitionName:
     Type: String
-    Default: 'raster-vision-gpu'
-    Description: Specifies the name of the Batch job definition
+    Default: 'raster-vision-gpu-testing'
+    Description: Specifies the name of the Batch Job Definition to create
 
   InstanceVCPUs:
     Type: Number
     Default: 8
-    Description: Number of VCPUs reserved for the container by the task definition
+    Description: Number of vCPUs reserved for the container by the task definition
 
   InstanceMemory:
     Type: Number
@@ -79,8 +159,8 @@ Parameters:
 
   RepositoryName:
     Type: String
-    Default: rastervision
-    Description: Specifies the name of the ECR repository to retrieve images from
+    Default: 'raster-vision-testing'
+    Description: Specifies the name of the ECR repository to create and retrieve images from
 
   ImageName:
     Type: String
@@ -90,14 +170,14 @@ Parameters:
   ImageTag:
     Type: String
     Default: latest
-    Description: Tag of the image to retrieve from ECR
+    Description: Tag of the container image to retrieve from ECR
 
   VPC:
     Type: 'AWS::EC2::VPC::Id'
     Description: Virtual Private Cloud in which to launch Batch instances
 
   SubnetIds:
-    Type: 'List<AWS:EC2::Subnet::Id>'
+    Type: 'List<AWS::EC2::Subnet::Id>'
     Description: >
       A list of IDs of subnets in which to launch Batch instances (all subnets
       must exist in the VPC you selected)
@@ -164,6 +244,7 @@ Resources:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
       VpcId: !Ref VPC
+      GroupDescription: !Join ['', ['Security group for ', !Ref Project, ' (', !Ref Environment, ')']]
       SecurityGroupIngress:
         -
           FromPort: 22
@@ -184,7 +265,7 @@ Resources:
       Tags:
         -
           Key: Name
-          Value: !Join ['', ['sgRasterVisionContainerInstance' !Ref Environment]]
+          Value: !Join ['', ['sgRasterVisionContainerInstance', !Ref Environment]]
         -
           Key: Project
           Value: !Ref Project
@@ -193,8 +274,9 @@ Resources:
           Value: !Ref Environment
 
   Repository:
-    Type: 'AWS::ECR::Repository',
-    RepositoryName: !Ref RepositoryName
+    Type: 'AWS::ECR::Repository'
+    Properties:
+      RepositoryName: !Ref RepositoryName
 
   BatchComputeEnvironment:
     Type: 'AWS::Batch::ComputeEnvironment'
@@ -208,28 +290,20 @@ Resources:
         BidPercentage: !Ref SpotFleetBidPercentage
         Ec2KeyPair: !Ref KeyName
         ImageId: !Ref AMI
-        MinvCpus: !Ref MinimumVCPUS
+        MinvCpus: !Ref MinimumVCPUs
         DesiredvCpus: !Ref DesiredVCPUs
         MaxvCpus: !Ref MaximumVCPUs
         SpotIamFleetRole: !Ref SpotFleetIAMRole
         InstanceRole: !Ref BatchInstanceProfile
-        Instancetypes: !Ref InstanceTypes
+        InstanceTypes: !Ref InstanceTypes
         SecurityGroupIds:
           - !Ref ContainerInstanceSecurityGroup
-        Subnets: !Split [',', !Ref SubnetIds]
+        Subnets: !Ref SubnetIds
         Tags:
-          -
-            Key: Name
-            Value: Raster Vision BatchWorker
-          -
-            Key: ComputeEnvironment
-            Value: Raster Vision
-          -
-            Key: Project
-            Value: !Ref Project
-          -
-            Key: Environment
-            Value: !Ref Environment
+          Name: Raster Vision BatchWorker
+          ComputeEnvironment: Raster Vision
+          Project: !Ref Project
+          Environment: !Ref Environment
 
   BatchJobQueue:
     Type: 'AWS::Batch::JobQueue'
@@ -243,21 +317,23 @@ Resources:
           Order: 1
 
   JobDefinition:
-    JobDefinitionName: !Ref JobDefinitionName
-    Type: Container
-    ContainerProperties:
-      Image: !Join ['', [!GetAtt Repository.Arn, '/', !Ref ImageName, ':', !Ref ImageTag]]
-      Vcpus: !Ref InstanceVCPUs
-      Memory: !Ref InstanceMemory
-      Volumes:
-        -
-          Host:
-            SourcePath: /home/ec2-user
-          Name: home
-      MountPoints:
-        -
-          ContainerPath: /opt/data
-          ReadOnly: false
-          SourceVolume: home
-      ReadOnlyRootFilesystem: false
-      Privileged: true
+    Type: 'AWS::Batch::JobDefinition'
+    Properties:
+      Type: Container
+      JobDefinitionName: !Ref JobDefinitionName
+      ContainerProperties:
+        Image: !Join ['', [!GetAtt Repository.Arn, '/', !Ref ImageName, ':', !Ref ImageTag]]
+        Vcpus: !Ref InstanceVCPUs
+        Memory: !Ref InstanceMemory
+        Volumes:
+          -
+            Host:
+              SourcePath: /home/ec2-user
+            Name: home
+        MountPoints:
+          -
+            ContainerPath: /opt/data
+            ReadOnly: false
+            SourceVolume: home
+        ReadonlyRootFilesystem: false
+        Privileged: true

--- a/settings.mk.template
+++ b/settings.mk.template
@@ -10,7 +10,7 @@ AWS_REGION := us-east-1
 
 # Settings for ECR
 RASTER_VISION_IMAGE := raster-vision-gpu
-ECR_IMAGE := rastervision
+ECR_IMAGE := raster-vision-gpu
 ECR_IMAGE_TAG := latest
 
 # Settings for Terraform


### PR DESCRIPTION
# Overview

Ports the Terraform stack to a CloudFormation template that can be used to deploy AWS resources.

Closes https://github.com/azavea/raster-vision-aws/issues/16.

## Demo

Parameters can now be configured via the Cloudformation UI:

<img width="1552" alt="screen shot 2018-12-18 at 12 49 48 pm" src="https://user-images.githubusercontent.com/14170650/50172613-779a7400-02c3-11e9-8662-555e2126a1e6.png">

## Notes

- This PR seeks to make as few changes as possible to the resource design -- instead, it simply seeks to port existing functionality to CloudFormation. Any changes from the existing infrastructure will be highlighted in comments in the code.

# Testing instructions

- Log into the R&D AWS console
- Navigate to `CloudFormation > Create Stack`
- In the `Choose a template field`, select `Upload a template to Amazon S3` and upload the template in `cloudformation/template.yml`
- Where available, use the default parameters. Specify the following required parameters:
    - `Stack Name`: `TestingCloudFormation`
    - `VPC`: `vpc-074e8ae6256f7c1ca` (the first one on the dropdown)
    - `Subnets`: `subnet-033d2cbe8268c3067` (the first one on the dropdown)
    - `SSH Key Name`: `raster-vision` (doesn't matter unless you want to shell into the instance)
- Accept all default options
- Accept `I acknowledge that AWS CloudFormation might create IAM resources with custom names` on the last screen
- Create the stack and confirm that it builds correctly
- Delete the stack and confirm that everything cleans up correctly