### PR TITLE
Add support for user namespacing of CloudFormation resources

### DIFF
--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -9,7 +9,7 @@ Metadata:
         Parameters:
           - Project
           - Environment
-          - Slug
+          - Prefix
       -
         Label:
           default: EC2 Instance Configuration
@@ -36,8 +36,8 @@ Metadata:
         default: Name
       Environment:
         default: Environment
-      Slug:
-        default: Slug
+      Prefix:
+        default: Prefix
       AMI:
         default: AMI
       KeyName:
@@ -71,7 +71,7 @@ Parameters:
   Project:
     Type: String
     Default: Raster Vision CloudFormation
-    Description: Name of the project to associate with new resources
+    Description: Name of the CloudFormation project to associate with new resources
 
   Environment:
     Type: String
@@ -81,7 +81,7 @@ Parameters:
     AllowedPattern: ^[a-zA-Z0-9]*$
     ConstraintDescription: must only contain uppercase and lowercase letters and numbers
 
-  Slug:
+  Prefix:
     Type: String
     Default: ""
     Description: >
@@ -166,7 +166,7 @@ Resources:
   BatchServiceIAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'BatchRole']]
+      RoleName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'BatchRole']]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -183,7 +183,7 @@ Resources:
   SpotFleetIAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'SpotFleetRole']]
+      RoleName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'SpotFleetRole']]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -200,7 +200,7 @@ Resources:
   BatchInstanceIAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'InstanceRole']]
+      RoleName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'InstanceRole']]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -221,14 +221,14 @@ Resources:
       Path: /
       Roles:
         - !Ref BatchInstanceIAMRole
-      InstanceProfileName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'InstanceProfile']]
+      InstanceProfileName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'InstanceProfile']]
 
   ContainerInstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref VPC
-      GroupName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'SecurityGroup']]
-      GroupDescription: !Join ['', ['Security group for ', !Ref Project, ' (', !Ref Environment, ',', !Ref Slug, ')']]
+      GroupName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'SecurityGroup']]
+      GroupDescription: !Join ['', ['Security group for ', !Ref Project, ' (', !Ref Environment, ',', !Ref Prefix, ')']]
       SecurityGroupIngress:
         -
           FromPort: 22
@@ -249,7 +249,7 @@ Resources:
       Tags:
         -
           Key: Name
-          Value: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'SecurityGroup']]
+          Value: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'SecurityGroup']]
         -
           Key: Project
           Value: !Ref Project
@@ -265,7 +265,7 @@ Resources:
   BatchComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
-      ComputeEnvironmentName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'ComputeEnvironment']]
+      ComputeEnvironmentName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'ComputeEnvironment']]
       Type: Managed
       State: ENABLED
       ServiceRole: !Ref BatchServiceIAMRole
@@ -284,7 +284,7 @@ Resources:
           - !Ref ContainerInstanceSecurityGroup
         Subnets: !Ref SubnetIds
         Tags:
-          Name: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'ComputeEnvironment']]
+          Name: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'ComputeEnvironment']]
           ComputeEnvironment: Raster Vision
           Project: !Ref Project
           Environment: !Ref Environment
@@ -292,7 +292,7 @@ Resources:
   BatchJobQueue:
     Type: AWS::Batch::JobQueue
     Properties:
-      JobQueueName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'JobQueue']]
+      JobQueueName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'JobQueue']]
       Priority: 1
       State: ENABLED
       ComputeEnvironmentOrder:
@@ -304,7 +304,7 @@ Resources:
     Type: AWS::Batch::JobDefinition
     Properties:
       Type: Container
-      JobDefinitionName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'JobDefinition']]
+      JobDefinitionName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'JobDefinition']]
       ContainerProperties:
         Image: !Join ['', [!GetAtt Repository.Arn, '/', !Ref ImageName, ':', !Ref ImageTag]]
         Vcpus: !Ref InstanceVCPUs

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -79,6 +79,7 @@ Parameters:
     Description: Environment of the project being deployed (e.g. Staging, Development, Production)
     MinLength: 1
     AllowedPattern: ^[a-zA-Z0-9]*$
+    ConstraintDescription: must only contain uppercase and lowercase letters and numbers
 
   Slug:
     Type: String
@@ -88,6 +89,7 @@ Parameters:
       RasterVisionIamRole becomes yournameRasterVisionIamRole)
     MaxLength: 12
     AllowedPattern: ^[a-z0-9]*$
+    ConstraintDescription: must only contain lowercase letters and numbers
 
   AMI:
     Type: AWS::EC2::Image::Id

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -9,6 +9,7 @@ Metadata:
         Parameters:
           - Project
           - Environment
+          - Slug
       -
         Label:
           default: EC2 Instance Configuration
@@ -30,16 +31,13 @@ Metadata:
           - ImageTag
           - InstanceVCPUs
           - InstanceMemory
-      -
-        Label:
-          default: Batch Configuration
-        Parameters:
-          - JobDefinitionName
     ParameterLabels:
       Project:
         default: Name
       Environment:
         default: Environment
+      Slug:
+        default: Slug
       AMI:
         default: AMI
       KeyName:
@@ -54,8 +52,6 @@ Metadata:
         default: Maximum vCPU Count
       InstanceTypes:
         default: Instance Types
-      JobDefinitionName:
-        default: Job Definition Name
       InstanceVCPUs:
         default: vCPU Limit
       InstanceMemory:
@@ -75,12 +71,23 @@ Parameters:
   Project:
     Type: String
     Default: Raster Vision CloudFormation
-    Description: Name of the project associated with the Batch job
+    Description: Name of the project to associate with new resources
 
   Environment:
     Type: String
     Default: Unknown
     Description: Environment of the project being deployed (e.g. Staging, Development, Production)
+    MinLength: 1
+    AllowedPattern: ^[a-zA-Z0-9]*$
+
+  Slug:
+    Type: String
+    Default: ""
+    Description: >
+      Optional identifier to use for namespacing your resources (e.g.
+      RasterVisionIamRole becomes yournameRasterVisionIamRole)
+    MaxLength: 12
+    AllowedPattern: ^[a-z0-9]*$
 
   AMI:
     Type: AWS::EC2::Image::Id
@@ -117,11 +124,6 @@ Parameters:
     Type: List<String>
     Default: p2.xlarge
     Description: A comma-separated list of instance types that may be launched
-
-  JobDefinitionName:
-    Type: String
-    Default: raster-vision-gpu-testing
-    Description: Specifies the name of the Batch Job Definition to create
 
   InstanceVCPUs:
     Type: Number
@@ -162,6 +164,7 @@ Resources:
   BatchServiceIAMRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'BatchRole']]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -178,6 +181,7 @@ Resources:
   SpotFleetIAMRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'SpotFleetRole']]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -194,6 +198,7 @@ Resources:
   BatchInstanceIAMRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'InstanceRole']]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -214,13 +219,14 @@ Resources:
       Path: /
       Roles:
         - !Ref BatchInstanceIAMRole
-      InstanceProfileName: !Join ['', ['BatchIAM', !Ref Environment]]
+      InstanceProfileName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'InstanceProfile']]
 
   ContainerInstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref VPC
-      GroupDescription: !Join ['', ['Security group for ', !Ref Project, ' (', !Ref Environment, ')']]
+      GroupName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'SecurityGroup']]
+      GroupDescription: !Join ['', ['Security group for ', !Ref Project, ' (', !Ref Environment, ',', !Ref Slug, ')']]
       SecurityGroupIngress:
         -
           FromPort: 22
@@ -241,7 +247,7 @@ Resources:
       Tags:
         -
           Key: Name
-          Value: sgRasterVisionContainerInstance
+          Value: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'SecurityGroup']]
         -
           Key: Project
           Value: !Ref Project
@@ -257,7 +263,7 @@ Resources:
   BatchComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
-      ComputeEnvironmentName: !Join ['', ['rasterVisionBatch', !Ref Environment, 'ComputeEnvironment']]
+      ComputeEnvironmentName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'ComputeEnvironment']]
       Type: Managed
       State: ENABLED
       ServiceRole: !Ref BatchServiceIAMRole
@@ -276,7 +282,7 @@ Resources:
           - !Ref ContainerInstanceSecurityGroup
         Subnets: !Ref SubnetIds
         Tags:
-          Name: Raster Vision BatchWorker
+          Name: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'ComputeEnvironment']]
           ComputeEnvironment: Raster Vision
           Project: !Ref Project
           Environment: !Ref Environment
@@ -284,7 +290,7 @@ Resources:
   BatchJobQueue:
     Type: AWS::Batch::JobQueue
     Properties:
-      JobQueueName: !Join ['' , ['rasterVisionQueue', !Ref Environment]]
+      JobQueueName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'JobQueue']]
       Priority: 1
       State: ENABLED
       ComputeEnvironmentOrder:
@@ -296,7 +302,7 @@ Resources:
     Type: AWS::Batch::JobDefinition
     Properties:
       Type: Container
-      JobDefinitionName: !Ref JobDefinitionName
+      JobDefinitionName: !Join ['', [!Ref Slug, 'RasterVision', !Ref Environment, 'JobDefinition']]
       ContainerProperties:
         Image: !Join ['', [!GetAtt Repository.Arn, '/', !Ref ImageName, ':', !Ref ImageTag]]
         Vcpus: !Ref InstanceVCPUs

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -7,8 +7,6 @@ Metadata:
         Label:
           default: Project Configuration
         Parameters:
-          - Project
-          - Environment
           - Prefix
       -
         Label:
@@ -32,10 +30,6 @@ Metadata:
           - InstanceVCPUs
           - InstanceMemory
     ParameterLabels:
-      Project:
-        default: Name
-      Environment:
-        default: Environment
       Prefix:
         default: Prefix
       AMI:
@@ -68,24 +62,11 @@ Metadata:
         default: Subnets
 
 Parameters:
-  Project:
-    Type: String
-    Default: Raster Vision CloudFormation
-    Description: Name of the CloudFormation project to associate with new resources
-
-  Environment:
-    Type: String
-    Default: Unknown
-    Description: Environment of the project being deployed (e.g. Staging, Development, Production)
-    MinLength: 1
-    AllowedPattern: ^[a-zA-Z0-9]*$
-    ConstraintDescription: must only contain uppercase and lowercase letters and numbers
-
   Prefix:
     Type: String
     Default: ""
     Description: >
-      Optional identifier to use for namespacing your resources (e.g.
+      Optional lowercase identifier to use for namespacing your resources (e.g.
       RasterVisionIamRole becomes yournameRasterVisionIamRole)
     MaxLength: 12
     AllowedPattern: ^[a-z0-9]*$
@@ -166,7 +147,7 @@ Resources:
   BatchServiceIAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'BatchRole']]
+      RoleName: !Join ['', [!Ref Prefix, 'RasterVisionBatchRole']]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -183,7 +164,7 @@ Resources:
   SpotFleetIAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'SpotFleetRole']]
+      RoleName: !Join ['', [!Ref Prefix, 'RasterVisionSpotFleetRole']]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -200,7 +181,7 @@ Resources:
   BatchInstanceIAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'InstanceRole']]
+      RoleName: !Join ['', [!Ref Prefix, 'RasterVisionInstanceRole']]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -221,14 +202,14 @@ Resources:
       Path: /
       Roles:
         - !Ref BatchInstanceIAMRole
-      InstanceProfileName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'InstanceProfile']]
+      InstanceProfileName: !Join ['', [!Ref Prefix, 'RasterVisionInstanceProfile']]
 
   ContainerInstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref VPC
-      GroupName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'SecurityGroup']]
-      GroupDescription: !Join ['', ['Security group for ', !Ref Project, ' (', !Ref Environment, ',', !Ref Prefix, ')']]
+      GroupName: !Join ['', [!Ref Prefix, 'RasterVisionSecurityGroup']]
+      GroupDescription: !Join ['', ['Security group for ', !Ref Prefix, ' (Raster Vision)']]
       SecurityGroupIngress:
         -
           FromPort: 22
@@ -249,13 +230,7 @@ Resources:
       Tags:
         -
           Key: Name
-          Value: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'SecurityGroup']]
-        -
-          Key: Project
-          Value: !Ref Project
-        -
-          Key: Environment
-          Value: !Ref Environment
+          Value: !Join ['', [!Ref Prefix, 'RasterVisionSecurityGroup']]
 
   Repository:
     Type: AWS::ECR::Repository
@@ -265,7 +240,7 @@ Resources:
   BatchComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
-      ComputeEnvironmentName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'ComputeEnvironment']]
+      ComputeEnvironmentName: !Join ['', [!Ref Prefix, 'RasterVisionComputeEnvironment']]
       Type: Managed
       State: ENABLED
       ServiceRole: !Ref BatchServiceIAMRole
@@ -284,15 +259,13 @@ Resources:
           - !Ref ContainerInstanceSecurityGroup
         Subnets: !Ref SubnetIds
         Tags:
-          Name: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'ComputeEnvironment']]
+          Name: !Join ['', [!Ref Prefix, 'RasterVisionComputeEnvironment']]
           ComputeEnvironment: Raster Vision
-          Project: !Ref Project
-          Environment: !Ref Environment
 
   BatchJobQueue:
     Type: AWS::Batch::JobQueue
     Properties:
-      JobQueueName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'JobQueue']]
+      JobQueueName: !Join ['', [!Ref Prefix, 'RasterVisionJobQueue']]
       Priority: 1
       State: ENABLED
       ComputeEnvironmentOrder:
@@ -304,7 +277,7 @@ Resources:
     Type: AWS::Batch::JobDefinition
     Properties:
       Type: Container
-      JobDefinitionName: !Join ['', [!Ref Prefix, 'RasterVision', !Ref Environment, 'JobDefinition']]
+      JobDefinitionName: !Join ['', [!Ref Prefix, 'RasterVisionJobDefinition']]
       ContainerProperties:
         Image: !Join ['', [!GetAtt Repository.Arn, '/', !Ref ImageName, ':', !Ref ImageTag]]
         Vcpus: !Ref InstanceVCPUs


### PR DESCRIPTION
## Overview

Prompt the user for a `Slug` parameter that will be used to namespace AWS resources in CloudFormation. Make sure that `Slug` is optional, such that CloudFormation reverts to sensible defaults in its absence.

Closes https://github.com/azavea/raster-vision-aws/issues/11.

## Notes

* The [original issue](https://github.com/azavea/raster-vision-aws/issues/11) noted that namespacing the ECR repo is particularly delicate. I agree, and decided not to change it in this PR, such that the repository name is still set as a parameter value (`RepositoryName`) that the user can adjust manually. My reasoning here is that I'm anticipating in https://github.com/azavea/raster-vision-aws/issues/12 that we'll want to make pulling the latest image from Quay the default behavior, and alter the `RepositoryName`, `ImageName`, and `ImageTag` parameters to be optional advanced overrides. I think this is ultimately the most convenient behavior for the template, since building and pushing your own image adds a lot of overhead to this workflow.

## Testing instructions

- Confirm that the template syntax is valid:

```
aws cloudformation validate-template --template-body file://cloudformation/template.yml
```

- Log into the R&D AWS console
- Navigate to `CloudFormation > Create Stack`
- In the `Choose a template field`, select `Upload a template to Amazon S3` and upload the template in `cloudformation/template.yml`
- Where available, use the default parameters. Specify the following required parameters:
    - `Stack Name`: `TestingCloudFormation`
    - `Slug`: A slug of your choosing
    - `VPC`: `vpc-074e8ae6256f7c1ca` (the first one on the dropdown)
    - `Subnets`: `subnet-033d2cbe8268c3067` (the first one on the dropdown)
    - `SSH Key Name`: `raster-vision` (doesn't matter unless you want to shell into the instance)
- Accept all default options on the Options screen
- Accept `I acknowledge that AWS CloudFormation might create IAM resources with custom names` on the Review screen
- Create the stack and confirm that it builds correctly
- Inspect resources and confirm that the namespacing works
- Delete the stack and confirm that everything cleans up correctly

