### PR TITLE
Add second job definition defaulting to hosted RV image

### DIFF
--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -23,11 +23,14 @@ Metadata:
           - CidrRange
       -
         Label:
-          default: Docker Container Configuration
+          default: Docker Image Configuration
         Parameters:
           - RepositoryName
-          - ImageName
           - ImageTag
+      -
+        Label:
+          default: Docker Container Configuration
+        Parameters:
           - InstanceVCPUs
           - InstanceMemory
     ParameterLabels:
@@ -55,8 +58,6 @@ Metadata:
         default: Memory Limit
       RepositoryName:
         default: Repository Name
-      ImageName:
-        default: Image Name
       ImageTag:
         default: Image Tag
       VPC:
@@ -133,18 +134,18 @@ Parameters:
 
   RepositoryName:
     Type: String
-    Default: raster-vision-testing
-    Description: Specifies the name of the ECR repository to create and retrieve images from
-
-  ImageName:
-    Type: String
-    Default: raster-vision-gpu
-    Description: Specifies the name of the container image to pull for Batch jobs
+    Default: ""
+    Description: >
+      (Optional) Specifies the name of an ECR repository to create for use in
+      pushing and pulling images -- if empty, pulls the latest Raster Vision
+      GPU image from Quay.io instead
 
   ImageTag:
     Type: String
-    Default: latest
-    Description: Tag of the container image to retrieve from ECR
+    Default: ""
+    Description: >
+      (Optional) Tag of the container image to retrieve from ECR -- required
+      if RepositoryName is not empty
 
   VPC:
     Type: AWS::EC2::VPC::Id
@@ -155,6 +156,10 @@ Parameters:
     Description: >
       A list of IDs of subnets in which to launch Batch instances (all subnets
       must exist in the VPC you selected)
+
+Conditions:
+  UseHostedDockerImage: !Equals [!Ref RepositoryName, ""]
+  UseCustomDockerImage: !Not [!Equals [!Ref RepositoryName, ""]]
 
 Resources:
   BatchServiceIAMRole:
@@ -247,6 +252,7 @@ Resources:
 
   Repository:
     Type: AWS::ECR::Repository
+    Condition: UseCustomDockerImage
     Properties:
       RepositoryName: !Ref RepositoryName
 
@@ -286,13 +292,37 @@ Resources:
           ComputeEnvironment: !Ref BatchComputeEnvironment
           Order: 1
 
-  JobDefinition:
+  CustomJobDefinition:
     Type: AWS::Batch::JobDefinition
+    Condition: UseCustomDockerImage
     Properties:
       Type: Container
-      JobDefinitionName: !Join ['', [!Ref Prefix, 'RasterVisionJobDefinition']]
+      JobDefinitionName: !Join ['', [!Ref Prefix, 'RasterVisionCustomJobDefinition']]
       ContainerProperties:
-        Image: !Join ['', [!GetAtt Repository.Arn, '/', !Ref ImageName, ':', !Ref ImageTag]]
+        Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${RepositoryName}:${ImageTag}"
+        Vcpus: !Ref InstanceVCPUs
+        Memory: !Ref InstanceMemory
+        Volumes:
+          -
+            Host:
+              SourcePath: /home/ec2-user
+            Name: home
+        MountPoints:
+          -
+            ContainerPath: /opt/data
+            ReadOnly: false
+            SourceVolume: home
+        ReadonlyRootFilesystem: false
+        Privileged: true
+
+  HostedJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Condition: UseHostedDockerImage
+    Properties:
+      Type: Container
+      JobDefinitionName: !Join ['', [!Ref Prefix, 'RasterVisionHostedJobDefinition']]
+      ContainerProperties:
+        Image: quay.io/azavea/raster-vision:gpu-latest
         Vcpus: !Ref InstanceVCPUs
         Memory: !Ref InstanceMemory
         Volumes:

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -23,14 +23,10 @@ Metadata:
           - CidrRange
       -
         Label:
-          default: Docker Image Configuration
+          default: Container Image Configuration
         Parameters:
           - RepositoryName
           - ImageTag
-      -
-        Label:
-          default: Docker Container Configuration
-        Parameters:
           - InstanceVCPUs
           - InstanceMemory
     ParameterLabels:
@@ -124,12 +120,12 @@ Parameters:
 
   InstanceVCPUs:
     Type: Number
-    Default: 8
+    Default: 4
     Description: Number of vCPUs reserved for the container by the task definition
 
   InstanceMemory:
     Type: Number
-    Default: 55000
+    Default: 40000
     Description: The hard limit (in MB) of memory to present to the container
 
   RepositoryName:
@@ -137,8 +133,8 @@ Parameters:
     Default: ""
     Description: >
       (Optional) Specifies the name of an ECR repository to create for use in
-      pushing and pulling images -- if empty, pulls the latest Raster Vision
-      GPU image from Quay.io instead
+      pushing and pulling container images -- if empty, pulls the latest
+      GPU-based Raster Vision container image from Quay.io instead
 
   ImageTag:
     Type: String
@@ -158,8 +154,8 @@ Parameters:
       must exist in the VPC you selected)
 
 Conditions:
-  UseHostedDockerImage: !Equals [!Ref RepositoryName, ""]
-  UseCustomDockerImage: !Not [!Equals [!Ref RepositoryName, ""]]
+  UseHostedContainerImage: !Equals [!Ref RepositoryName, ""]
+  UseCustomContainerImage: !Not [!Equals [!Ref RepositoryName, ""]]
 
 Resources:
   BatchServiceIAMRole:
@@ -252,7 +248,7 @@ Resources:
 
   Repository:
     Type: AWS::ECR::Repository
-    Condition: UseCustomDockerImage
+    Condition: UseCustomContainerImage
     Properties:
       RepositoryName: !Ref RepositoryName
 
@@ -294,7 +290,7 @@ Resources:
 
   CustomJobDefinition:
     Type: AWS::Batch::JobDefinition
-    Condition: UseCustomDockerImage
+    Condition: UseCustomContainerImage
     Properties:
       Type: Container
       JobDefinitionName: !Join ['', [!Ref Prefix, 'RasterVisionCustomJobDefinition']]
@@ -317,7 +313,7 @@ Resources:
 
   HostedJobDefinition:
     Type: AWS::Batch::JobDefinition
-    Condition: UseHostedDockerImage
+    Condition: UseHostedContainerImage
     Properties:
       Type: Container
       JobDefinitionName: !Join ['', [!Ref Prefix, 'RasterVisionHostedJobDefinition']]


### PR DESCRIPTION
## Overview

If the user does not specify a `RepositoryName` to create for use in pushing/pulling RV images, don't create the ECR repo and instead pull the latest RV image from Quay.io.

Closes https://github.com/azavea/raster-vision-aws/issues/12.

## Notes

- This PR branches off of #2.

## Testing instructions

### 1. Verify template syntax

- Confirm that the template syntax is valid:

```
aws cloudformation validate-template --template-body file://cloudformation/template.yml
```

### 2. Create job definition from ECR repo

- Log into the R&D AWS console
- Navigate to `CloudFormation > Create Stack`
- In the `Choose a template field`, select `Upload a template to Amazon S3` and upload the template in `cloudformation/template.yml`
- Where available, use the default parameters. Specify the following required parameters:
    - `Stack Name`: `TestingCloudFormation`
    - `Slug`: A slug of your choosing
    - `VPC`: `vpc-074e8ae6256f7c1ca` (the first one on the dropdown)
    - `Subnets`: `subnet-033d2cbe8268c3067` (the first one on the dropdown)
    - `SSH Key Name`: `raster-vision` (doesn't matter unless you want to shell into the instance)
- Specify a name and image tag for the ECR repo:
    - `Repository Name`: The name for your ECR repo (e.g. `raster-vision-gpu-testing`)
    - `Image Tag`: The tag for a Docker image (e.g. `latest`)
- Accept all default options on the Options screen
- Accept `I acknowledge that AWS CloudFormation might create IAM resources with custom names` on the Review screen
- Create the stack and confirm that it builds correctly
- Navigate to `Batch > Job definitions > ${slug}RasterVision${environment}CustomJobDefinition`
- Under the `Resource requirements` section, confirm that the job definition is pointing to the URI of the new ECR repo

### 3. Modify Stack to use hosted RV image

- Navigate to `CloudFormation > ${StackName} > Actions > Update stack`
- Select `Use current template` and hit `Next`
- Clear out the values from the `Repository Name` and `Image Tag` fields
- Accept all Options and update the stack
- Navigate to `Batch > Job definitions > ${slug}RasterVision${environment}HostedJobDefinition`
- Under the `Resource requirements` section, confirm that the job definition is pointing to the latest RV image on Quay.io
