### PR TITLE
Include variable for restricting inbound CIDR range

### DIFF
--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -22,6 +22,7 @@ Metadata:
           - MinimumVCPUs
           - DesiredVCPUs
           - MaximumVCPUs
+          - CidrRange
       -
         Label:
           default: Docker Image Configuration
@@ -53,6 +54,8 @@ Metadata:
         default: Desired vCPU Count
       MaximumVCPUs:
         default: Maximum vCPU Count
+      CidrRange:
+        default: CIDR Range
       InstanceTypes:
         default: Instance Types
       InstanceVCPUs:
@@ -122,6 +125,16 @@ Parameters:
     Type: Number
     Default: 80
     Description: The maximum number of EC2 vCPUs that an environment can reach
+
+  CidrRange:
+    Type: String
+    Default: 0.0.0.0/0
+    Description: >
+      Restrict inbound traffic to your EC2 instance to requests coming from
+      a specific CIDR range
+    # Pattern taken from: https://www.regexpal.com/94836
+    AllowedPattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$
+    ConstraintDescription: must be a valid IPv4 address or CIDR range
 
   InstanceTypes:
     Type: List<String>
@@ -239,12 +252,12 @@ Resources:
           FromPort: 22
           ToPort: 22
           IpProtocol: tcp
-          CidrIp: 0.0.0.0/0
+          CidrIp: !Ref CidrRange
         -
           FromPort: 6006
           ToPort: 6006
           IpProtocol: tcp
-          CidrIp: 0.0.0.0/0
+          CidrIp: !Ref CidrRange
       SecurityGroupEgress:
         -
           FromPort: 0


### PR DESCRIPTION
## Overview

Add the `CidrRange` variable to the CloudFormation template in order to allow the user to optionally restrict ingress to the EC2 instance to a known CIDR range.

Closes https://github.com/azavea/raster-vision-aws/issues/15.

## Notes

- Branches off of #3.

## Testing instructions

### 1. Verify template syntax

- Confirm that the template syntax is valid:

```
aws cloudformation validate-template --template-body file://cloudformation/template.yml
```

### 2. Create job definition with restricted CIDR range

- Log into the R&D AWS console
- Navigate to `CloudFormation > Create Stack`
- In the `Choose a template field`, select `Upload a template to Amazon S3` and upload the template in `cloudformation/template.yml`
- Where available, use the default parameters. Specify the following required parameters:
    - `Stack Name`: `TestingCloudFormation`
    - `Slug`: A slug of your choosing
    - `VPC`: `vpc-074e8ae6256f7c1ca` (the first one on the dropdown)
    - `Subnets`: `subnet-033d2cbe8268c3067` (the first one on the dropdown)
    - `SSH Key Name`: `raster-vision` (doesn't matter unless you want to shell into the instance)
- Update the `CIDR Range` parameter to point to the office IP address
- Accept all default options on the Options screen
- Accept `I acknowledge that AWS CloudFormation might create IAM resources with custom names` on the Review screen
- Create the stack and confirm that it builds correctly
- Navigate to `EC2 > Security Groups > ${slug}RasterVision${environment}SecurityGroup`
- Under the `Inbound` tab, confirm that the CIDR range is properly restricted

### 3. Test invalid CIDR range

- Navigate to `CloudFormation > ${StackName} > Actions > Update stack`
- Select `Use current template` and hit `Next`
- Clear out the `CIDR Range` parameter and use a dummy invalid string, like `foobarbaz`
- Attempt to create the stack and confirm that a template validation error appears