### PR TITLE
Remove reference to Packer bug from docs + add AWS_PROFILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You will be prompted to enter your AWS credentials, along with a default region.
 
 ## AMI Creation ##
 
-This step uses packer to install nvidia-docker on the base ECS AMI in order to run GPU jobs on AWS Batch. Note an occasional (issue)[https://github.com/azavea/raster-vision-cloudformation/issues/9] with using Packer.
+This step uses packer to install nvidia-docker on the base ECS AMI in order to run GPU jobs on AWS Batch.
 
 ### Configure the settings ###
 

--- a/settings.mk.template
+++ b/settings.mk.template
@@ -2,6 +2,7 @@
 AWS_BATCH_BASE_AMI := ami-XXXXXXXX
 AWS_ROOT_BLOCK_DEVICE_SIZE := 50
 AWS_REGION := us-east-1
+AWS_PROFILE := raster-vision
 
 # Settings for publish-container. These should be filled in after running the
 # Cloudformation setup (with the ECR fields set) and before running publish-container.


### PR DESCRIPTION
## Overview

This PR implements two tiny housekeeping changes that came out of further investigation into #9:

* Remove reference to intermittent Packer bug from docs, since I can't replicate it
* Add `AWS_PROFILE` to `settings.mk.template` so that the Packer build works even if the user hasn't run `export AWS_PROFILE=raster-vision`

Closes #9.

## Testing instructions

* Copy over the new settings template:

```
$ cp settings.mk.template settings.mk
```

* Adjust `AWS_BATCH_BASE_AMI` in `settings.mk` to use the latest DL Base AMI, `ami-003c401895188b246`
* Run `make create-ami` and confirm that the AMI builds properly