### PR TITLE
Add support for launch templates to Batch Compute Environments

### DIFF
--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -32,6 +32,8 @@ Metadata:
           - MaximumVCPUs
           - CidrRange
           - SpotFleetBidPercentage
+          - GpuLaunchTemplate
+          - CpuLaunchTemplate
       -
         Label:
           default: Container Image Parameters (Advanced)
@@ -84,6 +86,10 @@ Metadata:
         default: VPC
       SubnetIds:
         default: Subnets
+      GpuLaunchTemplate:
+        default: Launch Template (GPU)
+      CpuLaunchTemplate:
+        default: Launch Template (CPU)
 
 Parameters:
   Prefix:
@@ -208,11 +214,27 @@ Parameters:
       A list of IDs of subnets in which to launch Batch instances (all subnets
       must exist in the VPC you selected)
 
+  GpuLaunchTemplate:
+    Type: String
+    Default: ""
+    Description:
+      (Optional) The ID of an EC2 Launch Template to associate with the GPU-based
+      Batch Compute Environment.
+
+  CpuLaunchTemplate:
+    Type: String
+    Default: ""
+    Description:
+      (Optional) The ID of an EC2 Launch Template to associate with the CPU-based
+      Batch Compute Environment.
+
 Conditions:
   UseHostedGpuImage: !Equals [!Ref GpuRepositoryName, ""]
   UseCustomGpuImage: !Not [!Equals [!Ref GpuRepositoryName, ""]]
   UseHostedCpuImage: !Equals [!Ref CpuRepositoryName, ""]
   UseCustomCpuImage: !Not [!Equals [!Ref CpuRepositoryName, ""]]
+  UseGpuLaunchTemplate: !Not [!Equals [!Ref GpuLaunchTemplate, ""]]
+  UseCpuLaunchTemplate: !Not [!Equals [!Ref CpuLaunchTemplate, ""]]
 
 Resources:
   BatchServiceIAMRole:
@@ -336,6 +358,11 @@ Resources:
         SecurityGroupIds:
           - !Ref ContainerInstanceSecurityGroup
         Subnets: !Ref SubnetIds
+        LaunchTemplate:
+          !If
+            - UseGpuLaunchTemplate
+            - LaunchTemplateId: !Ref GpuLaunchTemplate
+            - !Ref "AWS::NoValue"
         Tags:
           Name: !Join ['', [!Ref Prefix, 'RasterVisionGpuComputeEnvironment']]
           ComputeEnvironment: Raster Vision
@@ -361,6 +388,11 @@ Resources:
         SecurityGroupIds:
           - !Ref ContainerInstanceSecurityGroup
         Subnets: !Ref SubnetIds
+        LaunchTemplate:
+          !If
+            - UseCpuLaunchTemplate
+            - LaunchTemplateId: !Ref CpuLaunchTemplate
+            - !Ref "AWS::NoValue"
         Tags:
           Name: !Join ['', [!Ref Prefix, 'RasterVisionCpuComputeEnvironment']]
           ComputeEnvironment: Raster Vision

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -33,7 +33,9 @@ Metadata:
           - CidrRange
           - SpotFleetBidPercentage
           - GpuLaunchTemplate
+          - GpuLaunchTemplateVersion
           - CpuLaunchTemplate
+          - CpuLaunchTemplateVersion
       -
         Label:
           default: Container Image Parameters (Advanced)
@@ -88,8 +90,12 @@ Metadata:
         default: Subnets
       GpuLaunchTemplate:
         default: Launch Template (GPU)
+      GpuLaunchTemplateVersion:
+        default: Launch Template Version (GPU)
       CpuLaunchTemplate:
         default: Launch Template (CPU)
+      CpuLaunchTemplateVersion:
+        default: Launch Template Version (CPU)
 
 Parameters:
   Prefix:
@@ -221,12 +227,26 @@ Parameters:
       (Optional) The ID of an EC2 Launch Template to associate with the GPU-based
       Batch Compute Environment.
 
+  GpuLaunchTemplateVersion:
+    Type: Number 
+    Default: 1
+    Description:
+      (Optional) The version of the EC2 Launch Template to associate with the GPU-based
+      Batch Compute Environment. 
+
   CpuLaunchTemplate:
     Type: String
     Default: ""
     Description:
       (Optional) The ID of an EC2 Launch Template to associate with the CPU-based
       Batch Compute Environment.
+
+  CpuLaunchTemplateVersion:
+    Type: Number 
+    Default: 1
+    Description:
+      (Optional) The version of the EC2 Launch Template to associate with the CPU-based
+      Batch Compute Environment. 
 
 Conditions:
   UseHostedGpuImage: !Equals [!Ref GpuRepositoryName, ""]
@@ -361,7 +381,9 @@ Resources:
         LaunchTemplate:
           !If
             - UseGpuLaunchTemplate
-            - LaunchTemplateId: !Ref GpuLaunchTemplate
+            -
+              LaunchTemplateId: !Ref GpuLaunchTemplate
+              Version: !Ref GpuLaunchTemplateVersion
             - !Ref "AWS::NoValue"
         Tags:
           Name: !Join ['', [!Ref Prefix, 'RasterVisionGpuComputeEnvironment']]
@@ -391,7 +413,9 @@ Resources:
         LaunchTemplate:
           !If
             - UseCpuLaunchTemplate
-            - LaunchTemplateId: !Ref CpuLaunchTemplate
+            -
+              LaunchTemplateId: !Ref GpuLaunchTemplate
+              Version: !Ref GpuLaunchTemplateVersion
             - !Ref "AWS::NoValue"
         Tags:
           Name: !Join ['', [!Ref Prefix, 'RasterVisionCpuComputeEnvironment']]


### PR DESCRIPTION
## Overview

Allow users to optionally thread in the ID of launch templates that they'd like to use for either CPU- or GPU-enabled jobs.

Closes #11.

## Notes

This approach requires a user to create a launch template separately from this CloudFormation stack and then thread it in. The downside of this approach is that the launch templates have to be managed separately from the CloudFormation stack, and more AWS labor/expertise is required of the user. The upside is that launch templates will be far more flexible than they would be if we tried to create default launch templates in the stack and then allow the user to tweak parameters in them. Since the addition of support for launch templates is intended to add flexibility to the module, I reasoned that the tradeoffs were acceptable for this approach. 

## Testing instructions

### 1. Test creating a stack without launch templates

* Create a stack following the instructions in https://github.com/azavea/raster-vision-aws#deploying-batch-resources
  * Use the `Raster Vision VPC`
  * Use the subnet `subnet-033d2cbe8268c3067`
  * Use the GPU AMI `ami-0d4fd80a4230ab510`
  * Use the CPU AMI `ami-011a85ba0ae2013bf`
  * Leave the values for GPU and CPU launch templates empty
* Confirm that resources build properly
* Tear down your stack

### 2. Test creating a stack with launch templates

* Create a launch template in `EC2 > Launch templates > Create launch template`
  * Under `Advanced details > User data`, add the following cloud-init config:

```
MIME-Version: 1.0
Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="

--==MYBOUNDARY==
Content-Type: text/cloud-config; charset="us-ascii"

runcmd:
- echo "hello, world!" > /home/ec2-user/helloworld.txt

--==MYBOUNDARY==--
```

* Create a new stack following the instructions in part 1
  * For the GPU and CPU launch templates, thread in the ID of the launch template you just created
* In your Batch job queue (either CPU or GPU), submit a job with the override command `cat /opt/data/helloworld.txt` and confirm that the job echos the hello world file that your launch template should create
* Delete the stack you created