### PR TITLE
Remove hardcoded region, close #21

### DIFF
--- a/packer/template-gpu.json
+++ b/packer/template-gpu.json
@@ -6,7 +6,7 @@
     "builders": [
         {
             "type": "amazon-ebs",
-            "region": "us-east-1",
+            "region": "{{env `AWS_REGION`}}",
             "source_ami": "{{user `aws_batch_base_ami`}}",
             "instance_type": "p3.2xlarge",
             "ssh_username": "ec2-user",

--- a/packer/template-gpu.json
+++ b/packer/template-gpu.json
@@ -1,12 +1,13 @@
 {
     "variables": {
         "aws_batch_base_ami": "{{env `AWS_BATCH_BASE_AMI`}}",
-        "aws_root_block_device_size": "{{env `AWS_ROOT_BLOCK_DEVICE_SIZE`}}"
+        "aws_root_block_device_size": "{{env `AWS_ROOT_BLOCK_DEVICE_SIZE`}}",
+        "region": "{{env `AWS_REGION`}}"
     },
     "builders": [
         {
             "type": "amazon-ebs",
-            "region": "{{env `AWS_REGION`}}",
+            "region": "{{user `region`}}",
             "source_ami": "{{user `aws_batch_base_ami`}}",
             "instance_type": "p3.2xlarge",
             "ssh_username": "ec2-user",

--- a/packer/template.json
+++ b/packer/template.json
@@ -5,7 +5,7 @@
     "builders": [
         {
             "type": "amazon-ebs",
-            "region": "us-east-1",
+            "region": "{{env `AWS_REGION`}}",
             "source_ami": "{{user `aws_batch_base_ami`}}",
             "instance_type": "c3.large",
             "ssh_username": "ec2-user",

--- a/packer/template.json
+++ b/packer/template.json
@@ -1,11 +1,12 @@
 {
     "variables": {
-        "aws_batch_base_ami": "{{env `AWS_BATCH_BASE_AMI`}}"
+        "aws_batch_base_ami": "{{env `AWS_BATCH_BASE_AMI`}}",
+        "region": "{{env `AWS_REGION`}}"
     },
     "builders": [
         {
             "type": "amazon-ebs",
-            "region": "{{env `AWS_REGION`}}",
+            "region": "{{user `region`}}",
             "source_ami": "{{user `aws_batch_base_ami`}}",
             "instance_type": "c3.large",
             "ssh_username": "ec2-user",


### PR DESCRIPTION
This makes the `AWS_REGION` configurable and fixes a bug in https://github.com/azavea/raster-vision-aws/pull/22. When testing that PR, I found a bug due to the fact that the `env` function can't be used outside the `user` variable block in the Packer template. See "Why can't I use environment variables elsewhere?" in https://www.packer.io/docs/templates/user-variables.html

Closes #21