### PR TITLE
Use prefix in LaunchTemplateNames

### DIFF
--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -324,7 +324,7 @@ Resources:
   GpuLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:
-      LaunchTemplateName: RasterVisionGpuLaunchTemplate
+      LaunchTemplateName: !Join ["", [!Ref Prefix, "RasterVisionGpuLaunchTemplate"]]
       LaunchTemplateData:
         BlockDeviceMappings:
           - DeviceName: /dev/xvda
@@ -363,7 +363,7 @@ Resources:
   CpuLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:
-      LaunchTemplateName: RasterVisionCpuLaunchTemplate
+      LaunchTemplateName: !Join ["", [!Ref Prefix, "RasterVisionCpuLaunchTemplate"]]
       LaunchTemplateData:
         BlockDeviceMappings:
           - DeviceName: /dev/xvda


### PR DESCRIPTION
Without this change, creating the stack fails because the LaunchTemplateName
has already been used in another stack. This fixes a bug in https://github.com/azavea/raster-vision-aws/pull/16 and was tested similarly.