### PR TITLE
Add CF template for new project/user-specific job defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Using Batch is advantageous because it starts and stops instances automatically 
 * [AWS Credentials](#aws-credentials)
 * [Deploying Batch resources](#deploying-batch-resources)
 * [Update Raster Vision configuration](#update-raster-vision-configuration)
+* [Deploy new job definitions](#deploy-new-job-definitions)
 
 ## AWS Account Setup ##
 
@@ -79,3 +80,7 @@ Run `make publish-images` to publish the images to your ECR repositories.
 ## Update Raster Vision configuration
 
 Finally, make sure to update your [Raster Vision configuration](https://docs.rastervision.io/en/latest/setup.html#setting-up-aws-batch) with the Batch resources that were created.
+
+## Deploy new job definitions
+
+When a user starts working on a new RV-based project (or a new user starts working on an existing RV-based project), they will often want to publish a custom Docker image to ECR and use it when running on Batch. To facilitate this, there is a separate [CloudFormation template for creating new job definitions](cloudformation/job_def_template.yml). The idea is that for each user/project pair which is identified by a `Namespace` string, a CPU and GPU job definition is created which point to a specified ECR repo using that `Namespace` as the tag. After creating these new resources, the image should be published to `repo:namespace` on ECR, and the new job definitions should be placed in a project-specific [RV profile file](https://docs.rastervision.io/en/latest/setup.html#setting-up-aws-batch).

--- a/cloudformation/job_def_template.yml
+++ b/cloudformation/job_def_template.yml
@@ -1,0 +1,111 @@
+Description: A CloudFormation template for deploying Batch job definitions for a specific Raster Vision project and user.
+
+Metadata:
+    AWS::CloudFormation::Interface:
+      ParameterLabels:
+        Namespace:
+          default: Namespace
+        RepositoryName:
+          default: ECR Repository Name
+        GPUInstanceVCPUs:
+          default: GPU vCPU Limit
+        GPUInstanceMemory:
+          default: GPU Memory Limit
+        CPUInstanceVCPUs:
+          default: CPU vCPU Limit
+        CPUInstanceMemory:
+          default: CPU Memory Limit
+
+Parameters:
+    Namespace:
+      Type: String
+      Default: ""
+      Description: >
+        Identifier for namespacing created resources. Best practice is to use a camel-cased
+        combination of your user id and the project name, ie. useridProjectName.
+      AllowedPattern: ^[A-Za-z0-9]*$
+      ConstraintDescription: must only contain letters and numbers
+
+    RepositoryName:
+      Type: String
+      Default: ""
+      Description: >
+        Specifies the name of the ECR repository to use for pushing and pulling images. If you are at Azavea and in doubt, raster-vision-team is a good choice.
+
+    GPUInstanceVCPUs:
+      Type: Number
+      Default: 8
+      Description: Number of vCPUs reserved for the container by the task definition for GPU instances (4 should be used for P2 instances)
+
+    GPUInstanceMemory:
+      Type: Number
+      Default: 55000
+      Description: The hard limit (in MB) of memory to present to the container for GPU instances (40000 should be used for P2 instances)
+
+    CPUInstanceVCPUs:
+      Type: Number
+      Default: 1
+      Description: Number of vCPUs reserved for the container by the task definition for CPU instances
+
+    CPUInstanceMemory:
+      Type: Number
+      Default: 6000
+      Description: The hard limit (in MB) of memory to present to the container for CPU instances
+
+Resources:
+    CpuJobDefinition:
+      Type: AWS::Batch::JobDefinition
+      Properties:
+        Type: Container
+        JobDefinitionName:
+          !Join ["", [!Ref Namespace, "CpuJobDefinition"]]
+        ContainerProperties:
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${RepositoryName}:${Namespace}"
+          Vcpus: !Ref CPUInstanceVCPUs
+          Memory: !Ref CPUInstanceMemory
+          Volumes:
+            - Host:
+                SourcePath: /home/ec2-user
+              Name: home
+            - Host:
+                SourcePath: /dev/shm
+              Name: shm
+          MountPoints:
+            - ContainerPath: /opt/data
+              ReadOnly: false
+              SourceVolume: home
+            - ContainerPath: /dev/shm
+              ReadOnly: false
+              SourceVolume: shm
+          ReadonlyRootFilesystem: false
+          Privileged: true
+
+    GpuJobDefinition:
+      Type: AWS::Batch::JobDefinition
+      Properties:
+        Type: Container
+        JobDefinitionName:
+          !Join ["", [!Ref Namespace, "GpuJobDefinition"]]
+        ContainerProperties:
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${RepositoryName}:${Namespace}"
+          Vcpus: !Ref GPUInstanceVCPUs
+          ResourceRequirements:
+            - Type: "GPU"
+              Value: "1"
+          Memory: !Ref GPUInstanceMemory
+          Volumes:
+            - Host:
+                SourcePath: /home/ec2-user
+              Name: home
+            - Host:
+                SourcePath: /dev/shm
+              Name: shm
+          MountPoints:
+            - ContainerPath: /opt/data
+              ReadOnly: false
+              SourceVolume: home
+            - ContainerPath: /dev/shm
+              ReadOnly: false
+              SourceVolume: shm
+          ReadonlyRootFilesystem: false
+          Privileged: true


### PR DESCRIPTION
This PR adds a new CloudFormation template for adding new project/user-specific job definitions. This makes it easier for a team to share the resources (eg. job queues and compute envs) created by the main CF template across projects, and only make new job defs (which point to a project/user-specific ECR repo and tag) for the project/user. 