### PR TITLE
Release v0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains the deployment code that sets up the necessary AWS reso
 
 Note: The `master` branch of this repo should be used in conjunction with the `master` branch (or `latest` Docker image tag) of [Raster Vision](https://github.com/azavea/raster-vision)
 which contains the latest changes. For versions of this repo that correspond to stable, released versions of Raster Vision, see:
+* [0.11](https://github.com/azavea/raster-vision-aws/tree/0.11)
 * [0.10](https://github.com/azavea/raster-vision-aws/tree/0.10)
 * [0.9](https://github.com/azavea/raster-vision-aws/tree/0.9)
 


### PR DESCRIPTION
This accompanies the final release (v0.11) of the current framework which will not be maintained. The subsequent release (v0.12) will introduce a major refactoring of the framework and the contents of this repo will move into the main RV repo.